### PR TITLE
Fix compiler warning

### DIFF
--- a/Adafruit_STMPE610.cpp
+++ b/Adafruit_STMPE610.cpp
@@ -278,7 +278,7 @@ uint8_t Adafruit_STMPE610::readRegister8(uint8_t reg) {
   return x;
 }
 uint16_t Adafruit_STMPE610::readRegister16(uint8_t reg) {
-  uint16_t x;
+  uint16_t x = 0;
   if (_CS == -1) {
    // use i2c
     Wire.beginTransmission(_i2caddr);


### PR DESCRIPTION
Very minor fix for compiler warning.

    Adafruit_STMPE610.cpp:312:10: warning: 'x' may be used uninitialized in this function [-Wmaybe-uninitialized]
       return x;
              ^
