### PR TITLE
Update Adafruit_STMPE610.cpp for HW SPI fix

### DIFF
--- a/Adafruit_STMPE610.cpp
+++ b/Adafruit_STMPE610.cpp
@@ -281,7 +281,7 @@ uint8_t Adafruit_STMPE610::readRegister8(uint8_t reg) {
     digitalWrite(_CS, HIGH);
 
     if (_CLK == -1)
-      SPI.endTransaction();
+      _spi->endTransaction();
   }
 
   return x;


### PR DESCRIPTION
Fixed issue where hardware SPI will not end the transaction by simply changing SPI.endTransaction(); to _spi->endTransaction();
